### PR TITLE
Fixed unreliability issues, and started working on Events

### DIFF
--- a/microblocks-adapter.js
+++ b/microblocks-adapter.js
@@ -114,7 +114,8 @@ class MicroBlocksAdapter extends Adapter {
     this.devices = new Map();
     this.buffer = [];
     addonManager.addAdapter(this);
-    startPairing();
+
+    this.startPairing();
   }
 
   startPairing(_timeoutSeconds) {

--- a/microblocks-adapter.js
+++ b/microblocks-adapter.js
@@ -114,8 +114,7 @@ class MicroBlocksAdapter extends Adapter {
     this.devices = new Map();
     this.buffer = [];
     addonManager.addAdapter(this);
-
-    this.startPairing();
+    startPairing();
   }
 
   startPairing(_timeoutSeconds) {
@@ -208,13 +207,7 @@ class MicroBlocksAdapter extends Adapter {
         // for all its variable names.
         this.write([
           0xFA,       // short message
-          0x06,       // stopAll opCode
-          0x00,       // object ID (irrelevant)
-          0xFA,       // short message
           0x05,       // startAll opCode
-          0x00,       // object ID (irrelevant)
-          0xFA,       // short message
-          0x09,       // getVarNames opCode
           0x00,       // object ID (irrelevant)
         ]);
 
@@ -223,7 +216,7 @@ class MicroBlocksAdapter extends Adapter {
           serialPort.close();
           clearTimeout(this);
           serialPort.discoveryTimeout = null;
-        }, 2000);
+        }, 1000);
       });
 
       serialPort.on('close', (err) => {
@@ -451,6 +444,12 @@ class MicroBlocksAdapter extends Adapter {
       mockThing.name = json.name;
       mockThing.capability = json['@type'];
       this.setPropertiesTimeout(mockThing);
+      console.log('found thing description');
+      mockThing.serialPort.write([
+          0xFA,       // short message
+          0x09,       // getVarNames opCode
+          0x00,       // object ID (irrelevant)
+      ]);
     } else if (message.indexOf('moz-property') === 0) {
       json = JSON.parse(message.substring(12));
       // get the variable name from the href: "/properties/varName" field

--- a/microblocks-adapter.js
+++ b/microblocks-adapter.js
@@ -473,8 +473,8 @@ class MicroBlocksAdapter extends Adapter {
       if (device) {
         let eventDescription = device.events.get(message);
         if (eventDescription) {
-          console.log('got event', eventDescription.name);
-          device.eventNotify(new Event(device, eventDescription.name));
+          console.log('got event', message);
+          device.eventNotify(new Event(device, message));
         }
       }
     }

--- a/microblocks-adapter.js
+++ b/microblocks-adapter.js
@@ -284,7 +284,7 @@ class MicroBlocksAdapter extends Adapter {
           );
         } else if (opCode === 0x14) {
           // outputValue opCode (for debugging)
-          console.log('board says:', this.getPayload(mockThing, dataSize));
+          console.log('device says:', this.getPayload(mockThing, dataSize));
         }
         mockThing.buffer = mockThing.buffer.slice(5 + dataSize);
         // there may be the start of a new message left to process
@@ -471,15 +471,11 @@ class MicroBlocksAdapter extends Adapter {
     } else {
       let device = this.getDevice(mockThing.name);
       if (device) {
-        console.log('got message', message, 'and treating it as an event');
         let eventDescription = device.events.get(message);
-        console.log(eventDescription);
-        device.eventNotify(
-          new Event(
-            device,
-            eventDescription['@type'],
-            eventDescription.name)
-        );
+        if (eventDescription) {
+          console.log('got event', eventDescription.name);
+          device.eventNotify(new Event(device, eventDescription.name));
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "microblocks-adapter",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "microblocks-adapter",
   "display_name": "MicroBlocks",
   "author": "MicroBlocks",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "MicroBlocks adapter plugin for Mozilla WebThings Gateway",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "microblocks-adapter",
   "display_name": "MicroBlocks",
   "author": "MicroBlocks",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MicroBlocks adapter plugin for Mozilla WebThings Gateway",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
This PR fixes a bug where boards would sometimes fail to pair due to mishandling of leftover MicroBlocks message parts upon connection attempts.

It also adds Events, but so far we've been unsuccessful in trying to trigger those.